### PR TITLE
Add tsc command option to brunch-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@ Or, do manual install:
 * If you want to use git version of plugin, add
 `"brunch-typescript": "git+ssh://git@github.com:baptistedonaux/brunch-typescript.git"`.
 
+## brunch-config
+Add the ``` tsc ``` command options to brunch-config.js as follows.
+
+``` js
+exports.config = {
+  plugins: {
+    brunchTypescript: {
+      tscOption: "--module commonJs"
+    }
+  }
+}
+```
+
 ## License
 
 The MIT License (MIT)

--- a/index.js
+++ b/index.js
@@ -17,15 +17,19 @@ module.exports = TypeScriptCompiler = (function() {
     }
 
     TypeScriptCompiler.prototype.compile = function(params, callback) {
-        var stderr = { 
-            Write: function (str) { 
-                process.stderr.write(str); 
-            }, 
-            WriteLine: function (str) { 
-                process.stderr.write(str + '\n'); 
-            }, 
-            Close: function () { 
-            } 
+        var opt = (typeof this.config.plugins.brunchTypescript === 'undefined'
+                    ? {} : this.config.plugins.brunchTypescript);
+        console.log("config.plugins.brunchTypescript:" + JSON.stringify(opt));
+
+        var stderr = {
+            Write: function (str) {
+                process.stderr.write(str);
+            },
+            WriteLine: function (str) {
+                process.stderr.write(str + '\n');
+            },
+            Close: function () {
+            }
         };
 
         var search = function(item, array){
@@ -41,11 +45,12 @@ module.exports = TypeScriptCompiler = (function() {
         var outFile = search(params.path, this.config.files.javascripts.joinTo);
 
         if (outFile != null) {
-            console.log(sysPath.join(__dirname));
-            var child = exec.exec(sysPath.join(__dirname) + '/node_modules/.bin/tsc --out ' + this.config.paths.public + '/' + outFile + ' ' + params.path,
-                function (error, stdout, stderr) {
-                    console.log("brunch-typescript");
+            var cmd = sysPath.join(__dirname) + '/node_modules/.bin/tsc --out '
+                        + this.config.paths.public + '/' + outFile + ' ' + params.path
+                        + (typeof opt.tscOption === 'undefined' ? '' : ' ' + opt.tscOption);
+            console.log(cmd);
 
+            var child = exec.exec(cmd, function (error, stdout, stderr) {
                     if (error !== null) {
                         // if (error !== null) {
                         //     console.log(error);


### PR DESCRIPTION
I added a functionality for using ``` tsc ``` command options like this.

## brunch-config
Add the ``` tsc ``` command options to brunch-config.js as follows.

``` js
exports.config = {
  plugins: {
    brunchTypescript: {
      tscOption: "--module commonJs"
    }
  }
}
```

Please check out my code.