### PR TITLE
Fix for source maps not working.

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,12 +74,13 @@ class TypeScriptCompiler {
       }
       const result = {data: compiled.outputText || compiled};
 
-      // Concatenation is broken by trailing comments in files, which occur
-      // frequently when comment nodes are lost in the AST from babel.
       result.data += '\n';
 
       if (compiled.sourceMapText) {
-        result.map = JSON.stringify(compiled.sourceMapText);
+        // Fix the sources path so Brunch can merge them.
+        const rawMap = JSON.parse(compiled.sourceMapText);
+        rawMap.sources[0] = params.path;
+        result.map = JSON.stringify(rawMap);
       }
       resolve(result);
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brunch-typescript",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Adds TypeScript support to brunch.",
   "author": "Baptiste Donaux (http://www.baptiste-donaux.fr)",
   "homepage": "https://github.com/baptistedonaux/brunch-typescript",


### PR DESCRIPTION
Discovered that the TypeScript sourceMaps weren't working because they didn't have the full path in the sources array. This PR fixes that, and I have confirmed that Brunch now uses them just fine.