### PR TITLE
Reduce error "noise"

### DIFF
--- a/transpile.js
+++ b/transpile.js
@@ -1,7 +1,13 @@
 'use strict';
 const ts = require('typescript');
 
-const filterErrors = err => err.code !== 1208;
+const ignoredErrors = new Set([
+  1208, // Cannot compile namespaces when the '--isolatedModules' flag is provided.
+  2307, // Cannot find module '{0}'.
+  2304, // Cannot find name '{0}'.
+  2339  // Property '{0}' does not exist on type '{1}'.
+]);
+const filterErrors = err => !ignoredErrors.has(err.code);
 
 module.exports = function transpileModule(input, transpileOptions) {
     var options = transpileOptions.compilerOptions ? ts.clone(transpileOptions.compilerOptions) : getDefaultCompilerOptions();


### PR DESCRIPTION
This should fix most of the issues people are having with 1.8.2 (specifically in #13). It also allows people to self-fix any errors they are seeing which they think they should not be.

If a `ignoreErrors` key is added to the plugin config it should be an array of error numbers to ignore. You can find the error numbers given as part of the error message.

This is a temporary fix as I think we need to figure out how to handle full project builds with module context. Perhaps as part of the full build vs the incremental compile.

/cc @paulmillr