### PR TITLE
Test and deployment integration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+
+root = true
+
+[{index,transpile}/.js]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,25 @@
+{
+    "env": {
+        "es6": true,
+        "node": true
+    },
+    "extends": "eslint:recommended",
+    "rules": {
+        "indent": [
+            "error",
+            4
+        ],
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "quotes": [
+            "error",
+            "double"
+        ],
+        "semi": [
+            "error",
+            "always"
+        ]
+    }
+}

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+.editorconfig
+.eslintrc.json
+.gitignore
+.travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ install:
   - npm install
 
 script:
-  # - npm test
+  - npm test
   - VERSION=`node -e "console.log(require('./package.json').version);"`
-  - if [ \( -n $TRAVIS_TAG \) -a \( $TRAVIS_TAG != $VERSION \) ]; then echo "Git Tag and package version mismatch"; fi
+  - if [ \( -n $TRAVIS_TAG \) -a \( $TRAVIS_TAG != $VERSION \) ]; then echo "Git Tag and package version mismatch" && exit 1; fi
 
 before_deploy: |
   if [ -z "$GITHUB_API_KEY" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,6 @@ node_js:
   - "6"
   - "node"
 
-branches:
-  only:
-    - master
-    - improvement
-
 install:
   - npm install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,12 @@ branches:
 install:
   - npm install
 
-script:
-  - npm test
-  - VERSION=`node -e "console.log(require('./package.json').version);"`
-  - if [ \( -n $TRAVIS_TAG \) -a \( $TRAVIS_TAG != $VERSION \) ]; then echo "Git Tag and package version mismatch"; fi
+script: |
+  npm test
+  VERSION=`node -e "console.log(require('./package.json').version);"`
+  if [ \( -n $TRAVIS_TAG \) -a \( $TRAVIS_TAG != $VERSION \) ]; then
+    echo "Git Tag and package version mismatch"
+  fi
 
 before_deploy: |
   if [ -z "$GITHUB_API_KEY" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,10 @@ branches:
 install:
   - npm install
 
-script: |
-  npm test
-  VERSION=`node -e "console.log(require('./package.json').version);"`
-  if [ \( -n $TRAVIS_TAG \) -a \( $TRAVIS_TAG != $VERSION \) ]; then
-    echo "Git Tag and package version mismatch"
-  fi
+script:
+  - npm test
+  - VERSION=`node -e "console.log(require('./package.json').version);"`
+  - if [ \( -n $TRAVIS_TAG \) -a \( $TRAVIS_TAG != $VERSION \) ]; then echo "Git Tag and package version mismatch"; fi
 
 before_deploy: |
   if [ -z "$GITHUB_API_KEY" ]; then
@@ -30,6 +28,7 @@ before_deploy: |
 
 deploy:
   provider: npm
+  email: $NPM_EMAIL
   api_key: $NPM_API_KEY
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - npm install
 
 script:
-  - npm test
+  # - npm test
   - VERSION=`node -e "console.log(require('./package.json').version);"`
   - if [ \( -n $TRAVIS_TAG \) -a \( $TRAVIS_TAG != $VERSION \) ]; then echo "Git Tag and package version mismatch"; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,23 +6,28 @@ node_js:
 
 branches:
   only:
-    - /^\d+\.\d+\.\d+$/
+    - master
 
 install:
   - npm install
 
 script:
   - npm test
+  - VERSION=`node -e "console.log(require('./package.json').version);"`
+  - if [ \( -n $TRAVIS_TAG \) -a \( $TRAVIS_TAG != $VERSION \) ]; then echo "Git Tag and package version mismatch"; fi
 
 before_deploy: |
   if [ -z "$GITHUB_API_KEY" ]; then
     echo "No GITHUB_API_KEY given ! Deployment skipped"
     exit 0
+  else
+    git tag $VERSION
+    git push https://baptistedonaux:$GITHUB_API_KEY@github.com/baptistedonaux/brunch-typescript --tags
   fi
 
 deploy:
+  provider: npm
+  api_key: $NPM_API_KEY
   on:
     tags: true
-  - VERSION=`node -e "console.log(require('./package.json').version);"`
-  - if [ $TRAVIS_TAG != $VERSION ]; then echo "Git Tag and package version mismatch" ; fi
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ node_js:
 branches:
   only:
     - master
+    - improvement
 
 install:
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,6 @@ before_deploy: |
   if [ -z "$GITHUB_API_KEY" ]; then
     echo "No GITHUB_API_KEY given ! Deployment skipped"
     exit 0
-  else
-    git tag $VERSION
-    git push https://baptistedonaux:$GITHUB_API_KEY@github.com/baptistedonaux/brunch-typescript --tags
   fi
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,25 @@ node_js:
   - "6"
   - "node"
 
-before_script:
+branches:
+  only:
+    - /^\d+\.\d+\.\d+$/
+
+install:
   - npm install
 
 script:
   - npm test
+
+before_deploy: |
+  if [ -z "$GITHUB_API_KEY" ]; then
+    echo "No GITHUB_API_KEY given ! Deployment skipped"
+    exit 0
+  fi
+
+deploy:
+  on:
+    tags: true
+  - VERSION=`node -e "console.log(require('./package.json').version);"`
+  - if [ $TRAVIS_TAG != $VERSION ]; then echo "Git Tag and package version mismatch" ; fi
+ 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ node_js:
   - "6"
   - "node"
 
+branches:
+  only:
+    - master
+    - /^\d+\.\d+\.\d+$/
+
 install:
   - npm install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: node_js
+node_js:
+  - "4"
+  - "6"
+  - "node"
+
+before_script:
+  - npm install
+
+script:
+  - npm test

--- a/index.js
+++ b/index.js
@@ -1,133 +1,158 @@
 /*global __dirname */
-'use strict';
-const transpileModule = require('./transpile');
-const ts = require('typescript');
-const anymatch = require('anymatch');
-const path = require('path');
+"use strict";
+
+const transpileModule = require("./transpile");
+const ts = require("typescript");
+const anymatch = require("anymatch");
+const path = require("path");
 
 const resolveEnum = (choice, opts) => {
-  const defaultValue = 1; // CommonJS/ES5/Preserve JSX defaults
-  if (!choice) {
-    return defaultValue;
-  }
-  if (!isNaN(choice)) {
-    return choice - 0;
-  }
-  for (let opt of Object.keys(opts)) {
-    if (choice && choice.toUpperCase() === opt.toUpperCase()) {
-      return opts[opt];
+    const defaultValue = 1; // CommonJS/ES5/Preserve JSX defaults
+
+    if (!choice) {
+        return defaultValue;
     }
-  }
-  return defaultValue;
+
+    if (!isNaN(choice)) {
+        return choice - 0;
+    }
+
+    for (let opt of Object.keys(opts)) {
+        if (choice && choice.toUpperCase() === opt.toUpperCase()) {
+            return opts[opt];
+        }
+    }
+    return defaultValue;
 };
 
 const getTsconfig = (root) => {
-  if (!root) {
-    return {};
-  }
-  const file = path.resolve(root, 'tsconfig.json');
-  let tsconf;
-  try {
-    tsconf = require(file);
-  } catch (e) {
-    return {};
-  }
-  return tsconf.compilerOptions || {};
+    if (!root) {
+        return {};
+    }
+
+    const file = path.resolve(root, "tsconfig.json");
+    let tsconf;
+
+    try {
+        tsconf = require(file);
+    } catch (e) {
+        return {};
+    }
+
+    return tsconf.compilerOptions || {};
 };
 
 
 const findLessOrEqual = (haystack, needle) => {
-  let i = 0;
-  while (i + 1 < haystack.length && needle >= haystack[i + 1]) {
-    i += 1;
-  }
-  return i === haystack.length ? -1 : i;
-}
+    let i = 0;
+
+    while (i + 1 < haystack.length && needle >= haystack[i + 1]) {
+        i += 1;
+    }
+
+    return i === haystack.length ? -1 : i;
+};
 
 const errPos = err => {
-  const lineIndex = findLessOrEqual(err.file.lineMap, err.start);
-  return `Line: ${lineIndex + 1}, Col: ${err.start - err.file.lineMap[lineIndex] + 1}`;
+    const lineIndex = findLessOrEqual(err.file.lineMap, err.start);
+
+    return `Line: ${lineIndex + 1}, Col: ${err.start - err.file.lineMap[lineIndex] + 1}`;
 };
 
 const toMeaningfulMessage = err => `Error ${err.code}: ${err.messageText} (${errPos(err)})`;
 
 class TypeScriptCompiler {
-  constructor(config) {
-    if (!config) config = {};
-    const options = config.plugins &&
-      config.plugins.brunchTypescript || {};
-    this.options = getTsconfig(config.paths && config.paths.root);
-    Object.keys(options).forEach(key => {
-      if (key === 'sourceMap' || key === 'ignore') return;
-      this.options[key] = options[key];
-    });
-    this.options.module = resolveEnum(this.options.module, ts.ModuleKind);
-    this.options.target = resolveEnum(this.options.target, ts.ScriptTarget);
-    this.options.jsx = resolveEnum(this.options.jsx, ts.JsxEmit);
-    this.options.emitDecoratorMetadata = this.options.emitDecoratorMetadata !== false,
-    this.options.experimentalDecorators = this.options.experimentalDecorators !== false,
-    this.options.noEmitOnError = false; // This can't be true when compiling this way.
-    delete this.options.moduleResolution;
-    this.options.sourceMap = !!config.sourceMaps;
-    this.isIgnored = anymatch(options.ignore || /^(bower_components|vendor|node_modules)/);
-    if (this.options.pattern) {
-      this.pattern = this.options.pattern;
-      delete this.options.pattern;
+    constructor(config) {
+        if (!config) {
+            config = {};
+        }
+
+        const options = config.plugins && config.plugins.brunchTypescript || {};
+        this.options = getTsconfig(config.paths && config.paths.root);
+
+        Object.keys(options).forEach(key => {
+            if (key === "sourceMap" || key === "ignore") return;
+            this.options[key] = options[key];
+        });
+
+        this.options.module = resolveEnum(this.options.module, ts.ModuleKind);
+        this.options.target = resolveEnum(this.options.target, ts.ScriptTarget);
+        this.options.jsx = resolveEnum(this.options.jsx, ts.JsxEmit);
+        this.options.emitDecoratorMetadata = this.options.emitDecoratorMetadata !== false,
+        this.options.experimentalDecorators = this.options.experimentalDecorators !== false,
+        this.options.noEmitOnError = false; // This can"t be true when compiling this way.
+
+        delete this.options.moduleResolution;
+        
+        this.options.sourceMap = !!config.sourceMaps;
+        this.isIgnored = anymatch(options.ignore || /^(bower_components|vendor|node_modules)/);
+
+        if (this.options.pattern) {
+            this.pattern = this.options.pattern;
+            delete this.options.pattern;
+        }
+
+        if (this.options.ignoreErrors) {
+            if (this.options.ignoreErrors === true) {
+                this.ignoreAllErrors = true;
+            } else {
+                this.ignoreErrors = new Set(this.options.ignoreErrors);
+            }
+
+            delete this.options.ignoreErrors;
+        }
     }
-    if (this.options.ignoreErrors) {
-      if (this.options.ignoreErrors === true) {
-        this.ignoreAllErrors = true;
-      } else {
-        this.ignoreErrors = new Set(this.options.ignoreErrors);
-      }
-      delete this.options.ignoreErrors;
-    }
-  }
+
+    compile(params) {
+        if (this.isIgnored(params.path)) {
+            return Promise.resolve(params);
+        }
+
+        let tsOptions = {
+            fileName: params.path,
+            reportDiagnostics: true,
+            compilerOptions: this.options
+        };
+
+        return new Promise((resolve, reject) => {
+            let compiled;
+
+            try {
+                compiled = transpileModule(params.data, tsOptions);
+                let reportable = compiled.diagnostics;
+
+                if (this.ignoreAllErrors === true) {
+                    reportable = [];
+                } else if (this.ignoreErrors) {
+                    reportable = reportable.filter(err => !this.ignoreErrors.has(err.code));
+                }
+
+                if (reportable.length) {
+                    reject(reportable.map(toMeaningfulMessage).join("\n"));
+                }
+            } catch (err) {
+                return reject(err);
+            }
+
+            const result = {data: compiled.outputText || compiled};
   
-  compile(params) {
-    if (this.isIgnored(params.path)) {
-      return Promise.resolve(params);
+            result.data += "\n";
+  
+            if (compiled.sourceMapText) {
+                // Fix the sources path so Brunch can merge them.
+                const rawMap = JSON.parse(compiled.sourceMapText);
+                rawMap.sources[0] = params.path;
+                result.map = JSON.stringify(rawMap);
+            }
+
+            resolve(result);
+        });
     }
-    let tsOptions = {
-      fileName: params.path,
-      reportDiagnostics: true,
-      compilerOptions: this.options
-    }
-
-    return new Promise((resolve, reject) => {
-      let compiled;
-      try {
-        compiled = transpileModule(params.data, tsOptions);
-        let reportable = compiled.diagnostics;
-        if (this.ignoreAllErrors === true) {
-          reportable = [];
-        } else if (this.ignoreErrors) {
-          reportable = reportable.filter(err => !this.ignoreErrors.has(err.code));
-        }
-        if (reportable.length) {
-          reject(reportable.map(toMeaningfulMessage).join('\n'));
-        }
-      } catch (err) {
-        return reject(err);
-      }
-      const result = {data: compiled.outputText || compiled};
-
-      result.data += '\n';
-
-      if (compiled.sourceMapText) {
-        // Fix the sources path so Brunch can merge them.
-        const rawMap = JSON.parse(compiled.sourceMapText);
-        rawMap.sources[0] = params.path;
-        result.map = JSON.stringify(rawMap);
-      }
-      resolve(result);
-    });
-  }
 }
 
 TypeScriptCompiler.prototype.brunchPlugin = true;
-TypeScriptCompiler.prototype.type = 'javascript';
-TypeScriptCompiler.prototype.extension = 'ts';
+TypeScriptCompiler.prototype.type = "javascript";
+TypeScriptCompiler.prototype.extension = "ts";
 TypeScriptCompiler.prototype.pattern = /\.ts(x)?$/;
 
 module.exports = TypeScriptCompiler;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "brunch-typescript",
   "version": "2.1.0",
   "description": "Adds TypeScript support to brunch.",
-  "author": "Baptiste Donaux (http://www.baptiste-donaux.fr)",
+  "author": "Baptiste Donaux <baptiste.donaux@gmail.com>",
   "contributors": [
     "Colin Bate <colin@colinbate.com>"
   ],
@@ -20,7 +20,7 @@
     "url": "https://github.com/baptistedonaux/brunch-typescript/issues"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "eslint *.js"
   },
   "keywords": [
     "typescript",
@@ -28,7 +28,9 @@
     "tsc"
   ],
   "license": "MIT",
-  "devDependencies": {},
+  "devDependencies": {
+    "eslint": "^3.13.1"
+  },
   "peerDependencies": {
     "brunch": "^2.2.0"
   }

--- a/transpile.js
+++ b/transpile.js
@@ -13,7 +13,7 @@ const ignoredErrors = new Set([
 const filterErrors = err => !ignoredErrors.has(err.code);
 
 module.exports = function transpileModule(input, transpileOptions) {
-    var options = transpileOptions.compilerOptions ? ts.clone(transpileOptions.compilerOptions) : getDefaultCompilerOptions();
+    var options = ts.clone(transpileOptions.compilerOptions);
 
     options.isolatedModules = true;
     // transpileModule does not write anything to disk so there is no need to verify that there are no conflicts between input and output paths. 


### PR DESCRIPTION
@colinbate ```brunch-typescript``` is now used by few developers. Thank you for your job and your implication.

To help futures improvements and help others developers to contribute on this plugin, I would like add test integration and deployment integration with Travis.

```npm test``` runs simply ESLint to check that code is formatted and respect our standard (for a best readable).

Next, I would like an auto-deployment with Travis CI.

Example :
- A contributor works on a feature or a fix. A PR is sent.
- Travis runs test. Tests have positive result.
- A contributor merges this PR. He check if ```package.json``` version is correctly incremented and add a Git tag wit the same value.
- Travis runs again the test, check that Git tag as same value as ```package.json``` version and deploys then on NPM.