### PR TITLE
Upgrade brunch-typescript and typescript-brunch.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+indent_size = 4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - node
+  - 6
+  - 4

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-/*global __dirname */
 'use strict';
+
 const transpileModule = require('./transpile');
 const ts = require('typescript');
 const anymatch = require('anymatch');
@@ -13,7 +13,7 @@ const resolveEnum = (choice, opts) => {
   if (!isNaN(choice)) {
     return choice - 0;
   }
-  for (let opt of Object.keys(opts)) {
+  for (const opt of Object.keys(opts)) {
     if (choice && choice.toUpperCase() === opt.toUpperCase()) {
       return opts[opt];
     }
@@ -21,7 +21,7 @@ const resolveEnum = (choice, opts) => {
   return defaultValue;
 };
 
-const getTsconfig = (root) => {
+const getTsconfig = root => {
   if (!root) {
     return {};
   }
@@ -42,7 +42,7 @@ const findLessOrEqual = (haystack, needle) => {
     i += 1;
   }
   return i === haystack.length ? -1 : i;
-}
+};
 
 const errPos = err => {
   const lineIndex = findLessOrEqual(err.file.lineMap, err.start);
@@ -83,16 +83,16 @@ class TypeScriptCompiler {
       delete this.options.ignoreErrors;
     }
   }
-  
+
   compile(params) {
     if (this.isIgnored(params.path)) {
       return Promise.resolve(params);
     }
-    let tsOptions = {
+    const tsOptions = {
       fileName: params.path,
       reportDiagnostics: true,
-      compilerOptions: this.options
-    }
+      compilerOptions: this.options,
+    };
 
     return new Promise((resolve, reject) => {
       let compiled;

--- a/index.js
+++ b/index.js
@@ -7,34 +7,30 @@ const path = require('path');
 
 const resolveEnum = (choice, opts) => {
   const defaultValue = 1; // CommonJS/ES5/Preserve JSX defaults
-  if (!choice) {
-    return defaultValue;
-  }
-  if (!isNaN(choice)) {
-    return choice - 0;
-  }
+
+  if (!choice) return defaultValue;
+  if (!isNaN(choice)) return choice - 0;
+
   for (const opt of Object.keys(opts)) {
     if (choice && choice.toUpperCase() === opt.toUpperCase()) {
       return opts[opt];
     }
   }
+
   return defaultValue;
 };
 
-const getTsconfig = root => {
-  if (!root) {
-    return {};
-  }
-  const file = path.resolve(root, 'tsconfig.json');
-  let tsconf;
+const getTsconfig = configRoot => {
+  if (!configRoot) return {};
+
+  const file = path.resolve(configRoot, 'tsconfig.json');
+
   try {
-    tsconf = require(file);
+    return require(file).compilerOptions;
   } catch (e) {
     return {};
   }
-  return tsconf.compilerOptions || {};
 };
-
 
 const findLessOrEqual = (haystack, needle) => {
   let i = 0;
@@ -53,27 +49,35 @@ const toMeaningfulMessage = err => `Error ${err.code}: ${err.messageText} (${err
 
 class TypeScriptCompiler {
   constructor(config) {
-    if (!config) config = {};
-    const options = config.plugins &&
-      config.plugins.brunchTypescript || {};
+    if (!config) {
+      config = {};
+    }
+
+    const options = config.plugins && config.plugins.brunchTypescript || {};
     this.options = getTsconfig(config.paths && config.paths.root);
+
     Object.keys(options).forEach(key => {
       if (key === 'sourceMap' || key === 'ignore') return;
       this.options[key] = options[key];
     });
+
     this.options.module = resolveEnum(this.options.module, ts.ModuleKind);
     this.options.target = resolveEnum(this.options.target, ts.ScriptTarget);
     this.options.jsx = resolveEnum(this.options.jsx, ts.JsxEmit);
-    this.options.emitDecoratorMetadata = this.options.emitDecoratorMetadata !== false,
-    this.options.experimentalDecorators = this.options.experimentalDecorators !== false,
-    this.options.noEmitOnError = false; // This can't be true when compiling this way.
+    this.options.emitDecoratorMetadata = this.options.emitDecoratorMetadata !== false;
+    this.options.experimentalDecorators = this.options.experimentalDecorators !== false;
+    this.options.noEmitOnError = false; // This can"t be true when compiling this way.
+
     delete this.options.moduleResolution;
+
     this.options.sourceMap = !!config.sourceMaps;
-    this.isIgnored = anymatch(options.ignore || /^(bower_components|vendor|node_modules)/);
+    this.isIgnored = anymatch(options.ignore || /(^bower_components|vendor|node_modules)/);
+
     if (this.options.pattern) {
       this.pattern = this.options.pattern;
       delete this.options.pattern;
     }
+
     if (this.options.ignoreErrors) {
       if (this.options.ignoreErrors === true) {
         this.ignoreAllErrors = true;
@@ -85,9 +89,8 @@ class TypeScriptCompiler {
   }
 
   compile(params) {
-    if (this.isIgnored(params.path)) {
-      return Promise.resolve(params);
-    }
+    if (this.isIgnored(params.path)) return Promise.resolve(params);
+
     const tsOptions = {
       fileName: params.path,
       reportDiagnostics: true,
@@ -96,23 +99,25 @@ class TypeScriptCompiler {
 
     return new Promise((resolve, reject) => {
       let compiled;
+
       try {
         compiled = transpileModule(params.data, tsOptions);
         let reportable = compiled.diagnostics;
+
         if (this.ignoreAllErrors === true) {
           reportable = [];
         } else if (this.ignoreErrors) {
           reportable = reportable.filter(err => !this.ignoreErrors.has(err.code));
         }
+
         if (reportable.length) {
           reject(reportable.map(toMeaningfulMessage).join('\n'));
         }
       } catch (err) {
         return reject(err);
       }
-      const result = {data: compiled.outputText || compiled};
 
-      result.data += '\n';
+      const result = {data: `${compiled.outputText || compiled}\n`};
 
       if (compiled.sourceMapText) {
         // Fix the sources path so Brunch can merge them.
@@ -120,6 +125,7 @@ class TypeScriptCompiler {
         rawMap.sources[0] = params.path;
         result.map = JSON.stringify(rawMap);
       }
+
       resolve(result);
     });
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/baptistedonaux/brunch-typescript/issues"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "eslint ."
   },
   "keywords": [
     "typescript",
@@ -28,8 +28,14 @@
     "tsc"
   ],
   "license": "MIT",
-  "devDependencies": {},
+  "devDependencies": {
+    "eslint": "^3.15.0",
+    "eslint-config-brunch": "^1.0.0"
+  },
   "peerDependencies": {
     "brunch": "^2.2.0"
+  },
+  "eslintConfig": {
+    "extends": "brunch"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "brunch-typescript",
   "version": "2.1.0",
-  "description": "Adds TypeScript support to brunch.",
-  "author": "Baptiste Donaux (http://www.baptiste-donaux.fr)",
+  "description": "Adds TypeScript support to Brunch.",
+  "author": "Baptiste Donaux <baptiste.donaux@gmail.com>",
   "contributors": [
     "Colin Bate <colin@colinbate.com>"
   ],
@@ -12,10 +12,9 @@
     "url": "git+ssh://git@github.com/baptistedonaux/brunch-typescript.git"
   },
   "main": "./index.js",
-  "dependencies": {
-    "anymatch": "^1.3.0",
-    "typescript": "2.1.*"
-  },
+  "files": [
+    "*.js"
+  ],
   "bugs": {
     "url": "https://github.com/baptistedonaux/brunch-typescript/issues"
   },
@@ -28,6 +27,10 @@
     "tsc"
   ],
   "license": "MIT",
+  "dependencies": {
+    "anymatch": "^1.3.0",
+    "typescript": "2.1.*"
+  },
   "devDependencies": {
     "eslint": "^3.15.0",
     "eslint-config-brunch": "^1.0.0"

--- a/transpile.js
+++ b/transpile.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const ts = require('typescript');
 
 const ignoredErrors = new Set([
@@ -8,39 +9,49 @@ const ignoredErrors = new Set([
   2322, // Type '{0}' is not assignable to type '{1}'.
   2339, // Property '{0}' does not exist on type '{1}'.
 ]);
+
 const filterErrors = err => !ignoredErrors.has(err.code);
 
 const transpileModule = (input, transpileOptions) => {
-  var options = ts.clone(transpileOptions.compilerOptions);
+  const options = ts.clone(transpileOptions.compilerOptions);
 
   options.isolatedModules = true;
-    // transpileModule does not write anything to disk so there is no need to verify that there are no conflicts between input and output paths.
+  // transpileModule does not write anything to disk so there is no need to verify that there are no conflicts between input and output paths.
   options.suppressOutputPathCheck = true;
-    // Filename can be non-ts file.
+  // Filename can be non-ts file.
   options.allowNonTsExtensions = true;
-    // We are not returning a sourceFile for lib file when asked by the program,
-    // so pass --noLib to avoid reporting a file not found error.
+  // We are not returning a sourceFile for lib file when asked by the program,
+  // so pass --noLib to avoid reporting a file not found error.
   options.noLib = true;
-    // We are not doing a full typecheck, we are not resolving the whole context,
-    // so pass --noResolve to avoid reporting missing file errors.
+  // We are not doing a full typecheck, we are not resolving the whole context,
+  // so pass --noResolve to avoid reporting missing file errors.
   options.noResolve = true;
-    // We do want to emit here, so specifically enable it.
+  // We do want to emit here, so specifically enable it.
   options.noEmit = false;
-    // if jsx is specified then treat file as .tsx
-  var inputFileName = transpileOptions.fileName || (options.jsx ? 'module.tsx' : 'module.ts');
-  var sourceFile = ts.createSourceFile(inputFileName, input, options.target);
+  // if jsx is specified then treat file as .tsx
+  const inputFileName = transpileOptions.fileName ||
+    (options.jsx ? 'module.tsx' : 'module.ts');
+
+  const sourceFile = ts.createSourceFile(inputFileName, input, options.target);
+
   if (transpileOptions.moduleName) {
     sourceFile.moduleName = transpileOptions.moduleName;
   }
+
   sourceFile.renamedDependencies = transpileOptions.renamedDependencies;
-  var newLine = ts.getNewLineCharacter(options);
-    // Output
-  var outputText;
-  var sourceMapText;
-    // Create a compilerHost object to allow the compiler to read and write files
-  var compilerHost = {
+
+  const newLine = ts.getNewLineCharacter(options);
+
+  // Output
+  let outputText;
+  let sourceMapText;
+
+  // Create a compilerHost object to allow the compiler to read and write files
+  const compilerHost = {
     getSourceFile(fileName /* target*/) {
-      return fileName === ts.normalizeSlashes(inputFileName) ? sourceFile : undefined;
+      return fileName === ts.normalizeSlashes(inputFileName) ?
+        sourceFile :
+        undefined;
     },
     writeFile(name, text /* writeByteOrderMark */) {
       if (ts.fileExtensionIs(name, '.map')) {
@@ -76,17 +87,21 @@ const transpileModule = (input, transpileOptions) => {
       return true;
     },
   };
-  var program = ts.createProgram([inputFileName], options, compilerHost);
-  var diagnostics;
+
+  const program = ts.createProgram([inputFileName], options, compilerHost);
+
+  let diagnostics;
   if (transpileOptions.reportDiagnostics) {
     diagnostics = [];
-    ts.addRange(/* to*/ diagnostics, /* from*/ program.getSyntacticDiagnostics(sourceFile));
-    ts.addRange(/* to*/ diagnostics, /* from*/ program.getSemanticDiagnostics(sourceFile).filter(filterErrors));
-    ts.addRange(/* to*/ diagnostics, /* from*/ program.getOptionsDiagnostics());
+    ts.addRange(/* to */ diagnostics, /* from */ program.getSyntacticDiagnostics(sourceFile));
+    ts.addRange(/* to */ diagnostics, /* from */ program.getSemanticDiagnostics(sourceFile).filter(filterErrors));
+    ts.addRange(/* to */ diagnostics, /* from */ program.getOptionsDiagnostics());
   }
-    // Emit
+
+  // Emit
   program.emit();
   ts.Debug.assert(outputText !== undefined, 'Output generation failed');
+
   return {outputText, diagnostics, sourceMapText};
 };
 

--- a/transpile.js
+++ b/transpile.js
@@ -6,68 +6,88 @@ const ignoredErrors = new Set([
   2307, // Cannot find module '{0}'.
   2304, // Cannot find name '{0}'.
   2322, // Type '{0}' is not assignable to type '{1}'.
-  2339  // Property '{0}' does not exist on type '{1}'.
+  2339, // Property '{0}' does not exist on type '{1}'.
 ]);
 const filterErrors = err => !ignoredErrors.has(err.code);
 
-module.exports = function transpileModule(input, transpileOptions) {
-    var options = transpileOptions.compilerOptions ? ts.clone(transpileOptions.compilerOptions) : getDefaultCompilerOptions();
-    options.isolatedModules = true;
-    // transpileModule does not write anything to disk so there is no need to verify that there are no conflicts between input and output paths. 
-    options.suppressOutputPathCheck = true;
+const transpileModule = (input, transpileOptions) => {
+  var options = ts.clone(transpileOptions.compilerOptions);
+
+  options.isolatedModules = true;
+    // transpileModule does not write anything to disk so there is no need to verify that there are no conflicts between input and output paths.
+  options.suppressOutputPathCheck = true;
     // Filename can be non-ts file.
-    options.allowNonTsExtensions = true;
+  options.allowNonTsExtensions = true;
     // We are not returning a sourceFile for lib file when asked by the program,
     // so pass --noLib to avoid reporting a file not found error.
-    options.noLib = true;
+  options.noLib = true;
     // We are not doing a full typecheck, we are not resolving the whole context,
     // so pass --noResolve to avoid reporting missing file errors.
-    options.noResolve = true;
+  options.noResolve = true;
     // We do want to emit here, so specifically enable it.
-    options.noEmit = false;
+  options.noEmit = false;
     // if jsx is specified then treat file as .tsx
-    var inputFileName = transpileOptions.fileName || (options.jsx ? "module.tsx" : "module.ts");
-    var sourceFile = ts.createSourceFile(inputFileName, input, options.target);
-    if (transpileOptions.moduleName) {
-        sourceFile.moduleName = transpileOptions.moduleName;
-    }
-    sourceFile.renamedDependencies = transpileOptions.renamedDependencies;
-    var newLine = ts.getNewLineCharacter(options);
+  var inputFileName = transpileOptions.fileName || (options.jsx ? 'module.tsx' : 'module.ts');
+  var sourceFile = ts.createSourceFile(inputFileName, input, options.target);
+  if (transpileOptions.moduleName) {
+    sourceFile.moduleName = transpileOptions.moduleName;
+  }
+  sourceFile.renamedDependencies = transpileOptions.renamedDependencies;
+  var newLine = ts.getNewLineCharacter(options);
     // Output
-    var outputText;
-    var sourceMapText;
+  var outputText;
+  var sourceMapText;
     // Create a compilerHost object to allow the compiler to read and write files
-    var compilerHost = {
-        getSourceFile: function (fileName, target) { return fileName === ts.normalizeSlashes(inputFileName) ? sourceFile : undefined; },
-        writeFile: function (name, text, writeByteOrderMark) {
-            if (ts.fileExtensionIs(name, ".map")) {
-                ts.Debug.assert(sourceMapText === undefined, "Unexpected multiple source map outputs for the file '" + name + "'");
-                sourceMapText = text;
-            }
-            else {
-                ts.Debug.assert(outputText === undefined, "Unexpected multiple outputs for the file: '" + name + "'");
-                outputText = text;
-            }
-        },
-        getDefaultLibFileName: function () { return "lib.d.ts"; },
-        useCaseSensitiveFileNames: function () { return false; },
-        getCanonicalFileName: function (fileName) { return fileName; },
-        getCurrentDirectory: function () { return ""; },
-        getNewLine: function () { return newLine; },
-        fileExists: function (fileName) { return fileName === inputFileName; },
-        readFile: function (fileName) { return ""; },
-        directoryExists: function (directoryExists) { return true; }
-    };
-    var program = ts.createProgram([inputFileName], options, compilerHost);
-    var diagnostics;
-    if (transpileOptions.reportDiagnostics) {
-        diagnostics = [];
-        ts.addRange(/*to*/ diagnostics, /*from*/ program.getSyntacticDiagnostics(sourceFile));
-        ts.addRange(/*to*/ diagnostics, /*from*/ program.getSemanticDiagnostics(sourceFile).filter(filterErrors));
-        ts.addRange(/*to*/ diagnostics, /*from*/ program.getOptionsDiagnostics());
-    }
+  var compilerHost = {
+    getSourceFile(fileName /* target*/) {
+      return fileName === ts.normalizeSlashes(inputFileName) ? sourceFile : undefined;
+    },
+    writeFile(name, text /* writeByteOrderMark */) {
+      if (ts.fileExtensionIs(name, '.map')) {
+        ts.Debug.assert(sourceMapText === undefined, `Unexpected multiple source map outputs for the file '${name}'`);
+        sourceMapText = text;
+      } else {
+        ts.Debug.assert(outputText === undefined, `Unexpected multiple outputs for the file: '${name}'`);
+        outputText = text;
+      }
+    },
+    getDefaultLibFileName() {
+      return 'lib.d.ts';
+    },
+    useCaseSensitiveFileNames() {
+      return false;
+    },
+    getCanonicalFileName(fileName) {
+      return fileName;
+    },
+    getCurrentDirectory() {
+      return '';
+    },
+    getNewLine() {
+      return newLine;
+    },
+    fileExists(fileName) {
+      return fileName === inputFileName;
+    },
+    readFile(/* fileName */) {
+      return '';
+    },
+    directoryExists(/* directoryExists */) {
+      return true;
+    },
+  };
+  var program = ts.createProgram([inputFileName], options, compilerHost);
+  var diagnostics;
+  if (transpileOptions.reportDiagnostics) {
+    diagnostics = [];
+    ts.addRange(/* to*/ diagnostics, /* from*/ program.getSyntacticDiagnostics(sourceFile));
+    ts.addRange(/* to*/ diagnostics, /* from*/ program.getSemanticDiagnostics(sourceFile).filter(filterErrors));
+    ts.addRange(/* to*/ diagnostics, /* from*/ program.getOptionsDiagnostics());
+  }
     // Emit
-    program.emit();
-    ts.Debug.assert(outputText !== undefined, "Output generation failed");
-    return { outputText: outputText, diagnostics: diagnostics, sourceMapText: sourceMapText };
-}
+  program.emit();
+  ts.Debug.assert(outputText !== undefined, 'Output generation failed');
+  return {outputText, diagnostics, sourceMapText};
+};
+
+module.exports = transpileModule;


### PR DESCRIPTION
Hey, @baptistedonaux, @jpoehls, @xtity, @colinbate and @kripod! Hello from @brunch team!

We've noticed that there are two plugins for TypeScript in Brunch ecosystem:

1. [typescript-brunch](https://www.npmjs.com/package/typescript-brunch)
2. [brunch-typescript](https://www.npmjs.com/package/brunch-typescript)

The first one has a correct name (in according to plugin's styleguide), but it seems like this plugin was abandoned. The second one (this plugin) has more downloads, better API and seems like the most popular solution for TypeScript with Brunch.

We would like to update this plugin a bit (in corresponding to brunch/brunch#1666) and merge this one with `typescript-brunch`. Would be great (if you agree, of course) to move this plugin under @brunch organization, where we will take care of this plugin.

This PR introduce few changes for merging this plugin with `typescript-brunch`. Also, I've noticed #28 — gonna keep in mind those changes.

I need your confirmation. Do you agree with that? Would you like to move this plugin under @brunch org?

Hey, @joshheyse! We need you help to get NPM ownership for `typescript-brunch` package. Could you help us with that?

---

**WIP:** Do not merge this PR! I'm still working on improvement of this plugin!